### PR TITLE
Update http-request-client to v1.6 and adopt URLSessionProtocol

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b2ae6794e5280face5357aebb6df072335d87209a9aa2a53bb9abeb4aa730ca1",
+  "originHash" : "cd6e8c62ffee433ca43dd69cdb3cce1a8b67a4257b3665ed6dfe53d0c7393489",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/indigo-ce/http-request-client",
       "state" : {
-        "revision" : "78d3df5ebf6b662e8ed86401fdc1cfda72b2e14e",
-        "version" : "1.5.0"
+        "revision" : "9133b9e19aabb60fa9194de6b291541fcc3823b4",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.7.4"),
     .package(url: "https://github.com/auth0/JWTDecode.swift", from: "4.0.0"),
     .package(url: "https://github.com/auth0/SimpleKeychain", from: "1.3.0"),
-    .package(url: "https://github.com/indigo-ce/http-request-client", from: "1.5.0"),
+    .package(url: "https://github.com/kean/Pulse.git", from: "5.1.4"),
+    .package(url: "https://github.com/indigo-ce/http-request-client", .upToNextMinor(from: "1.6.0")),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.6"),
   ],
   targets: [
@@ -31,6 +32,7 @@ let package = Package(
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "DependenciesMacros", package: "swift-dependencies"),
+        .product(name: "Pulse", package: "Pulse"),
         .product(name: "HTTPRequestClient", package: "http-request-client"),
         .product(name: "JWTDecode", package: "JWTDecode.swift"),
         .product(name: "Sharing", package: "swift-sharing"),

--- a/Sources/JWTAuth/JWTAuthClient.swift
+++ b/Sources/JWTAuth/JWTAuthClient.swift
@@ -3,6 +3,7 @@ import DependenciesMacros
 import Foundation
 import HTTPRequestBuilder
 import HTTPRequestClient
+import Pulse
 import Sharing
 
 /// A client for handling JWT-based authentication in Swift applications using TCA.
@@ -177,7 +178,7 @@ extension JWTAuthClient {
   public func send<T>(
     _ request: Request = .init(),
     decoder: JSONDecoder = .init(),
-    urlSession: URLSession = .shared,
+    urlSession: URLSessionProtocol = URLSession.shared,
     cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
     timeoutInterval: TimeInterval = 60,
     @RequestBuilder middleware: () -> RequestMiddleware = { identity }
@@ -210,7 +211,7 @@ extension JWTAuthClient {
     _ request: Request = .init(),
     refreshExpiredToken: Bool = true,
     decoder: JSONDecoder = .init(),
-    urlSession: URLSession = .shared,
+    urlSession: URLSessionProtocol = URLSession.shared,
     cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
     timeoutInterval: TimeInterval = 60,
     @RequestBuilder middleware: () -> RequestMiddleware = { identity }
@@ -259,7 +260,7 @@ extension JWTAuthClient {
   public func send<T, ServerError>(
     _ request: Request = .init(),
     decoder: JSONDecoder = .init(),
-    urlSession: URLSession = .shared,
+    urlSession: URLSessionProtocol = URLSession.shared,
     cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
     timeoutInterval: TimeInterval = 60,
     @RequestBuilder middleware: () -> RequestMiddleware = { identity }
@@ -296,7 +297,7 @@ extension JWTAuthClient {
     _ request: Request = .init(),
     decoder: JSONDecoder = .init(),
     refreshExpiredToken: Bool = true,
-    urlSession: URLSession = .shared,
+    urlSession: URLSessionProtocol = URLSession.shared,
     cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
     timeoutInterval: TimeInterval = 60,
     @RequestBuilder middleware: () -> RequestMiddleware = { identity }


### PR DESCRIPTION
## Summary

- Bumps `http-request-client` to `.upToNextMinor(from: "1.6.0")`
- Adds `Pulse` as a direct dependency (source of `URLSessionProtocol`)
- Updates all `send` and `sendAuthenticated` overloads in `JWTAuthClient` to accept `urlSession: URLSessionProtocol = URLSession.shared` instead of `URLSession`

## Test plan

- [x] All 35 existing tests pass with no changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)