### PR TITLE
Distinguish transient refresh failures from explicit rejections

### DIFF
--- a/Sources/JWTAuth/AuthTokens.swift
+++ b/Sources/JWTAuth/AuthTokens.swift
@@ -63,6 +63,16 @@ extension AuthTokens {
     case invalidToken
     /// The token has expired and is no longer valid.
     case expiredToken
+    /// The refresh token was explicitly rejected by the server.
+    ///
+    /// Throw this from a `JWTAuthClient.refresh` closure to signal that the
+    /// server definitively rejected the refresh token — for example, a 401
+    /// from `/auth/refresh`, or a refresh token that has expired or been
+    /// revoked. `JWTAuthClient.refreshExpiredTokens()` catches this specific
+    /// case and destroys the stored credentials; any other thrown error is
+    /// treated as transient (the tokens are preserved so a later retry can
+    /// succeed) and rethrown to the caller.
+    case refreshRejected
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
@@ -70,6 +80,7 @@ extension AuthTokens {
       case .missingToken: "The token seems to be missing."
       case .invalidToken: "The token is invalid."
       case .expiredToken: "The token is expired."
+      case .refreshRejected: "The refresh token was rejected by the server."
       }
     }
 

--- a/Sources/JWTAuth/AuthTokensClient.swift
+++ b/Sources/JWTAuth/AuthTokensClient.swift
@@ -103,18 +103,26 @@ extension AuthTokensClient: DependencyKey {
 
     @Sendable
     func persist(_ tokens: AuthTokens?) async throws {
-      // Set the tokens in memory cache
+      // Set the tokens in memory cache. We do this before the keychain
+      // writes so the in-memory session and persistent state both reflect
+      // the new tokens on success.
       @Shared(.authSession) var session
       $session.withLock { $0 = tokens?.toSession() }
 
-      // Delete the tokens from the keychain
-      try await keychainClient.delete(.accessToken)
-      try await keychainClient.delete(.refreshToken)
-
-      // Save the tokens to the keychain
+      // Save the new tokens to the keychain BEFORE deleting the old ones.
+      // `keychainClient.save` replaces any existing entry in place, so on
+      // a partial save failure the old tokens remain in the keychain and
+      // a later retry can succeed. The previous delete-then-save order
+      // wiped both keychain entries before the first save, so any save
+      // failure left the keychain empty and silently logged the user out
+      // on the next cold launch.
       if let tokens {
         try await keychainClient.save(tokens.access, .accessToken)
         try await keychainClient.save(tokens.refresh, .refreshToken)
+      } else {
+        // No tokens to save — destroy removes both entries explicitly.
+        try await keychainClient.delete(.accessToken)
+        try await keychainClient.delete(.refreshToken)
       }
     }
 

--- a/Sources/JWTAuth/AuthTokensClient.swift
+++ b/Sources/JWTAuth/AuthTokensClient.swift
@@ -109,16 +109,36 @@ extension AuthTokensClient: DependencyKey {
       @Shared(.authSession) var session
       $session.withLock { $0 = tokens?.toSession() }
 
-      // Save the new tokens to the keychain BEFORE deleting the old ones.
-      // `keychainClient.save` replaces any existing entry in place, so on
-      // a partial save failure the old tokens remain in the keychain and
-      // a later retry can succeed. The previous delete-then-save order
-      // wiped both keychain entries before the first save, so any save
-      // failure left the keychain empty and silently logged the user out
-      // on the next cold launch.
       if let tokens {
-        try await keychainClient.save(tokens.access, .accessToken)
-        try await keychainClient.save(tokens.refresh, .refreshToken)
+        // Capture the old values so we can restore them on a partial
+        // save failure. `keychainClient.save` does its own delete-then-
+        // set under the hood, so a set-throw after the internal delete
+        // leaves the corresponding entry empty. Restoring on failure
+        // keeps the keychain in a cold-launch-restorable state — the
+        // next `loadTokens()` returns the old pair (or nil if there
+        // were none originally) instead of nil because one of the
+        // new saves was mid-write.
+        let oldAccess = try? await keychainClient.load(.accessToken)
+        let oldRefresh = try? await keychainClient.load(.refreshToken)
+
+        do {
+          try await keychainClient.save(tokens.access, .accessToken)
+          try await keychainClient.save(tokens.refresh, .refreshToken)
+        } catch {
+          // Best-effort restore the old values. Use `try?` so a
+          // restore failure doesn't mask the original error.
+          if let oldAccess {
+            try? await keychainClient.save(oldAccess, .accessToken)
+          } else {
+            try? await keychainClient.delete(.accessToken)
+          }
+          if let oldRefresh {
+            try? await keychainClient.save(oldRefresh, .refreshToken)
+          } else {
+            try? await keychainClient.delete(.refreshToken)
+          }
+          throw error
+        }
       } else {
         // No tokens to save — destroy removes both entries explicitly.
         try await keychainClient.delete(.accessToken)

--- a/Sources/JWTAuth/Documentation.docc/AuthenticationFlow.md
+++ b/Sources/JWTAuth/Documentation.docc/AuthenticationFlow.md
@@ -137,7 +137,20 @@ case .failure(let apiError):
 
 ## Token Refresh
 
-Token refresh is handled automatically by the `sendAuthenticated` methods. However, you can also trigger it manually:
+Token refresh is handled automatically by the `sendAuthenticated` methods. However, you can also trigger it manually.
+
+`refreshExpiredTokens()` distinguishes between two failure modes:
+
+- **`AuthTokens.Error.refreshRejected`** — the server definitively rejected
+  the refresh token (e.g. 401 from `/auth/refresh`). The stored credentials
+  are automatically destroyed; the session becomes `.missing`. You can
+  observe this either via the thrown error (if the rejection was thrown
+  through `refreshExpiredTokens` directly — which currently swallows it and
+  lets `session?.tokens` go nil), or simply by watching `@Shared(.authSession)`.
+- **Any other error** — a transient failure (no network, timeout, decode
+  error, etc.). The stored credentials are **preserved**, and the error is
+  rethrown so you can show a retry option instead of silently logging the
+  user out.
 
 ```swift
 @Dependency(\.jwtAuthClient) var authClient
@@ -145,14 +158,21 @@ Token refresh is handled automatically by the `sendAuthenticated` methods. Howev
 do {
   try await authClient.refreshExpiredTokens()
 } catch AuthTokens.Error.missingToken {
-  // No tokens available, redirect to login
+  // No tokens in storage — route the user to login.
+  redirectToLogin()
 } catch {
-  // Refresh failed, tokens may be invalid
-  // Clear tokens and redirect to login
-  @Dependency(\.authTokensClient) var authTokensClient
-  try await authTokensClient.destroy()
+  // Transient failure (network, timeout, decode, keychain, etc).
+  // The stored refresh token is still valid — show a retry option.
+  showRetryAlert(error: error) {
+    try await authClient.refreshExpiredTokens()
+  }
 }
 ```
+
+> ⚠️ **Do not** call `authTokensClient.destroy()` from the generic `catch`
+> block. `refreshExpiredTokens()` already destroys credentials when the
+> server explicitly rejects the refresh token; wiping them on any other
+> failure will log the user out for a transient network hiccup.
 
 ## Logout Flow
 
@@ -189,16 +209,76 @@ struct ProfileFeature: Reducer {
 
 ### Automatic Logout on Token Expiry
 
-When refresh tokens expire, the client automatically clears all tokens:
+When the server definitively rejects a refresh token, the client clears all
+stored credentials — but only in that case. Transient refresh failures
+(network down, timeout, DNS error, etc.) preserve the credentials so a
+later retry can succeed.
 
 ```swift
-// This happens automatically in JWTAuthClient.refreshExpiredTokens()
+// This happens automatically inside JWTAuthClient.refreshExpiredTokens():
 do {
   let newTokens = try await refresh(tokens)
   try await authTokensClient.set(newTokens)
-} catch {
-  // Refresh failed, clear all tokens
+} catch AuthTokens.Error.refreshRejected {
+  // Server rejected the refresh token — credentials are gone.
   try await authTokensClient.destroy()
+} catch {
+  // Transient failure — leave the existing tokens alone so a later
+  // retry (next launch, next request, etc) can succeed.
+  throw error
+}
+```
+
+To opt into this behavior from your `refresh` closure, throw
+`AuthTokens.Error.refreshRejected` when the server explicitly rejects the
+refresh token:
+
+```swift
+extension JWTAuthClient: @retroactive DependencyKey {
+  static let liveValue = Self(
+    baseURL: { "https://api.example.com" },
+    refresh: { tokens in
+      let response: TokenResponse = try await httpClient.send(
+        baseURL: host, decoder: .api, urlSession: session
+      ) {
+        Path("api", "v1", "auth", "refresh")
+        post(RefreshTokenRequest(refreshToken: tokens.refresh), encoder: .api)
+      }.value
+
+      return AuthTokens(
+        access: response.accessToken,
+        refresh: response.refreshToken
+      )
+    }
+  )
+}
+```
+
+If `httpClient.send` throws a `URLError` (e.g. `cannotConnectToHost`) or
+any other transport-level error, `refreshExpiredTokens()` will treat it as
+transient, preserve the credentials, and rethrow. If it throws because the
+server returned a 401, your `refresh` closure should re-throw it as
+`AuthTokens.Error.refreshRejected` so the library can destroy the
+credentials — for example:
+
+```swift
+refresh: { tokens in
+  do {
+    let response: TokenResponse = try await httpClient.send(
+      baseURL: host, decoder: .api, urlSession: session
+    ) {
+      Path("api", "v1", "auth", "refresh")
+      post(RefreshTokenRequest(refreshToken: tokens.refresh), encoder: .api)
+    }.value
+    return AuthTokens(
+      access: response.accessToken,
+      refresh: response.refreshToken
+    )
+  } catch let error as APIError where error.statusCode == 401 {
+    // Server explicitly rejected the refresh token.
+    throw AuthTokens.Error.refreshRejected
+  }
+  // Any other error propagates and is treated as transient.
 }
 ```
 
@@ -247,9 +327,16 @@ do {
   // Token is malformed
   try await authTokensClient.destroy()
   redirectToLogin()
+} catch AuthTokens.Error.refreshRejected {
+  // Server rejected the refresh token. `refreshExpiredTokens()` has
+  // already destroyed the credentials — just route to login.
+  redirectToLogin()
 } catch {
-  // Other network or API errors
-  handleGeneralError(error)
+  // Transient failure (network, timeout, decode, etc.). The refresh
+  // token is still valid; show a retry option instead of logging out.
+  showRetryAlert(error: error) {
+    try await authClient.sendAuthenticated(.get("/protected-resource"))
+  }
 }
 ```
 

--- a/Sources/JWTAuth/Documentation.docc/ErrorHandling.md
+++ b/Sources/JWTAuth/Documentation.docc/ErrorHandling.md
@@ -10,9 +10,10 @@ Errors related to token validation and processing:
 
 ```swift
 public enum AuthTokens.Error: LocalizedError {
-  case missingToken    // No token available
-  case invalidToken    // Token format is invalid
-  case expiredToken    // Token has expired
+  case missingToken     // No token available
+  case invalidToken     // Token format is invalid
+  case expiredToken     // Token has expired
+  case refreshRejected  // Server explicitly rejected the refresh token
 }
 ```
 
@@ -30,6 +31,11 @@ do {
 } catch AuthTokens.Error.expiredToken {
   // This usually won't happen with auto-refresh
   try await authClient.refreshExpiredTokens()
+} catch AuthTokens.Error.refreshRejected {
+  // The refresh endpoint told us the refresh token is no longer valid.
+  // `authClient.refreshExpiredTokens()` will already have destroyed the
+  // stored credentials for you; route the user back to the login screen.
+  showLoginScreen()
 }
 ```
 
@@ -61,52 +67,74 @@ do {
 
 ### 1. Network Errors During Token Refresh
 
+`refreshExpiredTokens()` only destroys the stored credentials when the server
+**explicitly** rejects the refresh token (via `AuthTokens.Error.refreshRejected`).
+Anything else — `URLError.cannotConnectToHost`, `.notConnectedToInternet`,
+`.timedOut`, DNS failures, decode errors, 5xx responses — is treated as
+transient: the stored tokens are **left intact** and the error is rethrown so
+the caller can decide whether to surface a retry option.
+
 ```swift
 @Dependency(\.jwtAuthClient) var authClient
+@Dependency(\.authTokensClient) var authTokensClient
 
 do {
   try await authClient.refreshExpiredTokens()
+} catch AuthTokens.Error.missingToken {
+  // No tokens in storage — route the user to login.
+  redirectToLogin()
+} catch AuthTokens.Error.refreshRejected {
+  // Server said the refresh token is no longer valid.
+  // `refreshExpiredTokens()` has already destroyed the stored credentials,
+  // so we just need to react.
+  redirectToLogin()
 } catch {
+  // Transient failure: bad network, timeout, decode error, etc. The
+  // stored tokens are still valid — let the user retry.
   if error.isNetworkError {
-    // Show retry option
     showNetworkErrorAlert(retry: {
       try await authClient.refreshExpiredTokens()
     })
   } else {
-    // Authentication failed, clear tokens
-    try await authTokensClient.destroy()
-    redirectToLogin()
+    showRetryAlert(error: error) {
+      try await authClient.refreshExpiredTokens()
+    }
   }
 }
 ```
 
+> ⚠️ **Important:** Do **not** call `authTokensClient.destroy()` from your
+> generic `catch` block. `refreshExpiredTokens()` already destroys credentials
+> when a definitive rejection happens, and you do not want to wipe a still-
+> valid refresh token on a transient network blip.
+
 ### 2. Server Returns Invalid Tokens
 
+When the refresh endpoint rejects the request, the `refresh` closure should
+signal that as `AuthTokens.Error.refreshRejected` so the library knows the
+credentials are no longer valid and destroys them. **Do not** call
+`authTokensClient.destroy()` from inside `refresh` — that would wipe the
+session on every transient failure too.
+
 ```swift
-// In your refresh implementation
 extension JWTAuthClient: @retroactive DependencyKey {
   static let liveValue = Self(
     baseURL: { "https://api.example.com" },
     refresh: { tokens in
       do {
         let response = try await refreshTokensFromServer(tokens)
-
-        // Validate the new tokens before returning
-        let newTokens = AuthTokens(
+        return AuthTokens(
           access: response.accessToken,
           refresh: response.refreshToken
         )
-
-        // This will throw if tokens are invalid
-        _ = try newTokens.toJWT()
-
-        return newTokens
-      } catch {
-        // If refresh fails, clear all tokens
-        @Dependency(\.authTokensClient) var authTokensClient
-        try await authTokensClient.destroy()
-        throw error
+      } catch let error as APIError where error.statusCode == 401 {
+        // Server explicitly rejected the refresh token.
+        // Tell the library to destroy the credentials.
+        throw AuthTokens.Error.refreshRejected
       }
+      // Any other error (URLError, decoding failure, 5xx, etc.) is
+      // automatically treated as transient by `refreshExpiredTokens()`
+      // and the stored tokens are preserved.
     }
   )
 }
@@ -150,7 +178,11 @@ extension ErrorHandler: DependencyKey {
 
       switch error {
       case AuthTokens.Error.missingToken,
-           AuthTokens.Error.invalidToken:
+           AuthTokens.Error.invalidToken,
+           AuthTokens.Error.refreshRejected:
+        // For `refreshRejected`, `refreshExpiredTokens()` has already
+        // destroyed the stored credentials before rethrowing; the
+        // remaining cases need us to do it ourselves.
         try await authTokensClient.destroy()
         NotificationCenter.default.post(name: .authenticationRequired, object: nil)
 
@@ -226,6 +258,9 @@ extension Error {
 
     case AuthTokens.Error.invalidToken:
       return "Authentication error. Please log in again"
+
+    case AuthTokens.Error.refreshRejected:
+      return "Your session is no longer valid. Please log in again"
 
     case KeychainError.savingFailed:
       return "Unable to securely save your login. Please try again"

--- a/Sources/JWTAuth/Documentation.docc/ErrorHandling.md
+++ b/Sources/JWTAuth/Documentation.docc/ErrorHandling.md
@@ -548,14 +548,14 @@ extension AuthTokens {
 
 ```swift
 extension JWTAuthClient {
-  static let failingTestValue = Self(
+  static let rejectionMock = Self(
     baseURL: { "https://test.api" },
     refresh: { _ in
-      throw AuthTokens.Error.expiredToken
+      throw AuthTokens.Error.refreshRejected
     }
   )
 
-  static let networkErrorTestValue = Self(
+  static let transientErrorMock = Self(
     baseURL: { "https://test.api" },
     refresh: { _ in
       throw URLError(.notConnectedToInternet)
@@ -567,19 +567,28 @@ extension JWTAuthClient {
 ### Error Testing
 
 ```swift
-func testTokenRefreshFailure() async throws {
-  withDependencies {
-    $0.jwtAuthClient = .failingTestValue
+@Test func refreshExpiredTokensDestroysOnRejection() async throws {
+  // `.refreshRejected` is the explicit server-rejection signal.
+  // `refreshExpiredTokens()` swallows it, destroys the stored
+  // credentials, and returns normally — the caller does not see
+  // the error. Route the user to login.
+  await withDependencies {
+    $0.jwtAuthClient = .rejectionMock
   } operation: {
     @Dependency(\.jwtAuthClient) var authClient
+    try await authClient.refreshExpiredTokens()
+  }
+}
 
-    do {
+@Test func refreshExpiredTokensRethrowsTransientErrors() async throws {
+  // A transient `URLError` is rethrown so the caller can offer
+  // a retry. The stored credentials are preserved.
+  await withDependencies {
+    $0.jwtAuthClient = .transientErrorMock
+  } operation: {
+    @Dependency(\.jwtAuthClient) var authClient
+    await #expect(throws: URLError.self) {
       try await authClient.refreshExpiredTokens()
-      XCTFail("Expected error")
-    } catch AuthTokens.Error.expiredToken {
-      // Expected error
-    } catch {
-      XCTFail("Unexpected error: \(error)")
     }
   }
 }
@@ -587,7 +596,7 @@ func testTokenRefreshFailure() async throws {
 
 ## Best Practices
 
-1. **Always handle authentication errors** by clearing tokens and redirecting to login
+1. **Handle rejection and transient errors differently.** Only ``AuthTokens/Error/refreshRejected`` should clear tokens and route the user to login — and `refreshExpiredTokens()` already destroys the stored credentials for you. All other errors (network, timeout, decode, keychain save, ``AuthTokens/Error/expiredToken``, ``AuthTokens/Error/invalidToken``) are transient: surface a retry option instead of logging the user out.
 2. **Provide user-friendly error messages** instead of technical details
 3. **Implement retry logic** for network errors
 4. **Log errors appropriately** for debugging without exposing sensitive data

--- a/Sources/JWTAuth/Documentation.docc/ErrorHandling.md
+++ b/Sources/JWTAuth/Documentation.docc/ErrorHandling.md
@@ -2,6 +2,75 @@
 
 This guide covers comprehensive error handling strategies for the JWT Auth Client.
 
+## Migration: Upgrading to the new refresh contract
+
+`JWTAuthClient.refreshExpiredTokens()` previously treated **any** error
+from the `refresh` closure as proof that the refresh token was invalid and
+destroyed the stored credentials. That meant a transient network failure
+silently and permanently logged the user out.
+
+The new contract introduces ``AuthTokens/Error/refreshRejected`` as the
+**explicit** signal for "the server definitively rejected the refresh
+token." Only that case destroys credentials; anything else (network
+errors, decode errors, keychain save failures, etc.) is rethrown and
+preserves the stored tokens so a later retry can succeed.
+
+### Before (any error → destroy)
+
+```swift
+refresh: { tokens in
+  do {
+    return try await refreshFromServer(tokens)
+  } catch {
+    // Library treats any error as a server-side rejection and
+    // destroys the stored credentials. A transient URLError
+    // here would log the user out.
+    throw error
+  }
+}
+```
+
+### After (explicit `.refreshRejected` signal)
+
+```swift
+refresh: { tokens in
+  do {
+    return try await refreshFromServer(tokens)
+  } catch let error as APIError where error.statusCode == 401 {
+    // Server explicitly said the refresh token is no longer valid.
+    // Tell the library to destroy the credentials.
+    throw AuthTokens.Error.refreshRejected
+  }
+  // Any other error (URLError, decode, 5xx, etc.) is treated as
+  // transient — the stored tokens are preserved and the error is
+  // rethrown so the caller can offer a retry option.
+}
+```
+
+### Migration checklist for existing consumers
+
+1. **Audit your `refresh` closure** for any path that throws
+   ``AuthTokens/Error/expiredToken`` or ``AuthTokens/Error/invalidToken``
+   to signal a bad refresh token. Replace those with
+   ``AuthTokens/Error/refreshRejected``. The legacy cases are **not**
+   treated as rejection aliases — they fall through to the transient
+   branch and preserve the stale tokens, which is the correct behavior
+   for network/decode/keychain errors but the wrong behavior when the
+   server has actually told you the refresh token is dead.
+
+2. **Audit centralized error handlers** that previously called
+   `authTokensClient.destroy()` on ``AuthTokens/Error/invalidToken`` or
+   ``AuthTokens/Error/expiredToken``. With the new contract, those
+   errors are transient — destroying on them will log the user out
+   transient-style. Only ``AuthTokens/Error/refreshRejected`` should
+   trigger destruction, and `refreshExpiredTokens()` already handles
+   that case for you. The example handler in
+   <doc:#Centralized-Error-Handling> has been updated accordingly.
+
+3. **Audit your `sendAuthenticated` error handling.** Transient failures
+   are now rethrown (network, timeout, decode, keychain save). Surface
+   a retry option instead of redirecting to login.
+
 ## Error Types
 
 ### AuthTokens.Error
@@ -25,12 +94,20 @@ do {
   // Redirect to login
   showLoginScreen()
 } catch AuthTokens.Error.invalidToken {
-  // Clear corrupted tokens
-  try await authTokensClient.destroy()
-  showLoginScreen()
+  // Token format is invalid. With the new refresh contract this is
+  // not a server-rejection signal — only `.refreshRejected` is. If
+  // the closure that called `toJWT()` was a `refresh` closure, treat
+  // this as transient and surface a retry instead of logging the
+  // user out.
+  showRetryAlert(error: error) {
+    try await authClient.refreshExpiredTokens()
+  }
 } catch AuthTokens.Error.expiredToken {
-  // This usually won't happen with auto-refresh
-  try await authClient.refreshExpiredTokens()
+  // Access token is expired. With auto-refresh this shouldn't reach
+  // the caller; if it does, treat as transient.
+  showRetryAlert(error: error) {
+    try await authClient.refreshExpiredTokens()
+  }
 } catch AuthTokens.Error.refreshRejected {
   // The refresh endpoint told us the refresh token is no longer valid.
   // `authClient.refreshExpiredTokens()` will already have destroyed the
@@ -177,18 +254,26 @@ extension ErrorHandler: DependencyKey {
       @Dependency(\.authTokensClient) var authTokensClient
 
       switch error {
-      case AuthTokens.Error.missingToken,
-           AuthTokens.Error.invalidToken,
-           AuthTokens.Error.refreshRejected:
-        // For `refreshRejected`, `refreshExpiredTokens()` has already
-        // destroyed the stored credentials before rethrowing; the
-        // remaining cases need us to do it ourselves.
+      case AuthTokens.Error.missingToken:
+        // No tokens in storage. Destroy is a no-op here; route to login.
         try await authTokensClient.destroy()
         NotificationCenter.default.post(name: .authenticationRequired, object: nil)
 
-      case AuthTokens.Error.expiredToken:
-        @Dependency(\.jwtAuthClient) var authClient
-        try await authClient.refreshExpiredTokens()
+      case AuthTokens.Error.refreshRejected:
+        // The server rejected the refresh token. `refreshExpiredTokens()`
+        // has already destroyed the stored credentials before rethrowing;
+        // we just need to route to login.
+        NotificationCenter.default.post(name: .authenticationRequired, object: nil)
+
+      case AuthTokens.Error.invalidToken,
+           AuthTokens.Error.expiredToken:
+        // With the new refresh contract these are not rejection signals —
+        // they indicate the access token was malformed/expired (and the
+        // library attempted a refresh that also failed transiently) or
+        // the refresh closure itself threw one of the legacy cases. In
+        // both situations the stored tokens are still potentially
+        // valid for a later retry. Surface a retry option.
+        NotificationCenter.default.post(name: .retryAuth, object: error)
 
       default:
         break

--- a/Sources/JWTAuth/Documentation.docc/Testing.md
+++ b/Sources/JWTAuth/Documentation.docc/Testing.md
@@ -47,10 +47,15 @@ extension JWTAuthClient {
 
   static let successMock = mock()
 
+  /// Mock that simulates a definitive rejection from the refresh endpoint.
+  /// `refreshExpiredTokens()` will destroy the stored credentials.
   static let failureMock = mock(
-    refreshResult: .failure(AuthTokens.Error.expiredToken)
+    refreshResult: .failure(AuthTokens.Error.refreshRejected)
   )
 
+  /// Mock that simulates a transient network failure.
+  /// `refreshExpiredTokens()` will preserve the stored credentials and
+  /// rethrow the `URLError` so the caller can decide to retry.
   static let networkErrorMock = mock(
     refreshResult: .failure(URLError(.notConnectedToInternet))
   )
@@ -291,6 +296,9 @@ func testSessionConversion() {
 ```swift
 func testTokenRefreshFailure() async throws {
   await withDependencies {
+    // `.failureMock` throws `AuthTokens.Error.refreshRejected`, which
+    // `refreshExpiredTokens()` treats as a definitive rejection — it
+    // destroys the credentials and returns without throwing.
     $0.jwtAuthClient = .failureMock
     $0.authTokensClient = AuthTokensClient.mock()
   } operation: {
@@ -300,17 +308,44 @@ func testTokenRefreshFailure() async throws {
     // Set up expired session
     session = .expired(TestData.expiredTokens)
 
+    // `refreshExpiredTokens()` does NOT rethrow `.refreshRejected`; it
+    // destroys the session instead.
+    await XCTAssertNoThrowAsync {
+      try await authClient.refreshExpiredTokens()
+    }
+
+    // Verify session was cleared due to rejection
+    XCTAssertEqual(session, .missing)
+  }
+}
+```
+
+### Transient Refresh Failure Test
+
+```swift
+func testTransientRefreshFailure() async throws {
+  await withDependencies {
+    // `.networkErrorMock` throws a `URLError`. `refreshExpiredTokens()`
+    // treats this as transient: it preserves the credentials and rethrows.
+    $0.jwtAuthClient = .networkErrorMock
+    $0.authTokensClient = AuthTokensClient.mock()
+  } operation: {
+    @Dependency(\.jwtAuthClient) var authClient
+    @Shared(.authSession) var session
+
+    session = .expired(TestData.expiredTokens)
+
     do {
       try await authClient.refreshExpiredTokens()
-      XCTFail("Expected refresh to fail")
-    } catch AuthTokens.Error.expiredToken {
-      // Expected error
+      XCTFail("Expected network error")
+    } catch let error as URLError {
+      XCTAssertEqual(error.code, .notConnectedToInternet)
     } catch {
       XCTFail("Unexpected error: \(error)")
     }
 
-    // Verify session was cleared due to refresh failure
-    XCTAssertEqual(session, .missing)
+    // Session is preserved — a later retry can succeed.
+    XCTAssertEqual(session, .expired(TestData.expiredTokens))
   }
 }
 ```

--- a/Sources/JWTAuth/Documentation.docc/TokenManagement.md
+++ b/Sources/JWTAuth/Documentation.docc/TokenManagement.md
@@ -276,6 +276,10 @@ do {
   // Token format is invalid
 } catch AuthTokens.Error.expiredToken {
   // Token has expired
+} catch AuthTokens.Error.refreshRejected {
+  // The refresh endpoint rejected the refresh token. Credentials have
+  // already been destroyed by `refreshExpiredTokens()`; redirect to login.
+  redirectToLogin()
 } catch KeychainError.savingFailed(let message) {
   // Keychain operation failed
   print("Keychain error: \(message)")
@@ -294,8 +298,12 @@ func handleTokenError(_ error: Error) async {
     try? await authClient.refreshExpiredTokens()
 
   case AuthTokens.Error.invalidToken,
-       AuthTokens.Error.missingToken:
-    // Clear invalid tokens and redirect to login
+       AuthTokens.Error.missingToken,
+       AuthTokens.Error.refreshRejected:
+    // Server definitively said the refresh token is no longer valid
+    // (or the stored tokens are missing/malformed). For `.refreshRejected`,
+    // `refreshExpiredTokens()` has already destroyed the credentials;
+    // the other cases need us to do it ourselves.
     try? await authTokensClient.destroy()
     redirectToLogin()
 
@@ -306,11 +314,19 @@ func handleTokenError(_ error: Error) async {
     redirectToLogin()
 
   default:
-    // Other errors
-    showError(error.localizedDescription)
+    // Transient failure (network, timeout, decode, etc.) — surface a
+    // retry option instead of wiping the still-valid session.
+    showRetryAlert(error: error) {
+      try? await authClient.refreshExpiredTokens()
+    }
   }
 }
 ```
+
+> ⚠️ **Important:** Do not call `authTokensClient.destroy()` from the
+> `default` branch. `refreshExpiredTokens()` already wipes the credentials
+> when the server explicitly rejects the refresh token, and a transient
+> network failure should preserve them so a later retry can succeed.
 
 ## Testing Token Management
 

--- a/Sources/JWTAuth/JWTAuthClient.swift
+++ b/Sources/JWTAuth/JWTAuthClient.swift
@@ -65,9 +65,52 @@ public struct JWTAuthClient: Sendable {
   /// This closure should implement your token refresh logic, typically by calling
   /// your API's token refresh endpoint with the provided refresh token.
   ///
+  /// ## Reporting failures
+  ///
+  /// The error type thrown from this closure controls how
+  /// `JWTAuthClient.refreshExpiredTokens()` reacts:
+  ///
+  /// - Throw ``AuthTokens/Error/refreshRejected`` when the server *explicitly*
+  ///   rejected the refresh token — for example, an HTTP 401 from
+  ///   `/auth/refresh`, an expired or revoked refresh token, or a server-side
+  ///   logout. `refreshExpiredTokens()` will treat this as a definitive
+  ///   rejection, destroy the stored credentials, and force the user to log in
+  ///   again.
+  /// - Throw any other error to indicate a *transient* failure: the network
+  ///   is unreachable, the request timed out, DNS failed, the response could
+  ///   not be decoded, etc. `refreshExpiredTokens()` will leave the existing
+  ///   tokens intact (so a later retry can succeed) and rethrow the error to
+  ///   the caller so it can decide whether to surface a retry option.
+  ///
+  /// Concretely, the typical implementation looks like this:
+  ///
+  /// ```swift
+  /// refresh: { tokens in
+  ///   do {
+  ///     let response: TokenResponse = try await httpClient.send(
+  ///       baseURL: host, decoder: .api, urlSession: session
+  ///     ) {
+  ///       Path("api", "v1", "auth", "refresh")
+  ///       post(RefreshTokenRequest(refreshToken: tokens.refresh), encoder: .api)
+  ///     }.value
+  ///     return AuthTokens(access: response.accessToken, refresh: response.refreshToken)
+  ///   } catch let error as APIError where error.statusCode == 401 {
+  ///     // Server explicitly said the refresh token is no longer valid.
+  ///     throw AuthTokens.Error.refreshRejected
+  ///   }
+  ///   // Any other error (URLError, decoding failure, 5xx, etc.) is
+  ///   // automatically treated as transient.
+  /// }
+  /// ```
+  ///
   /// - Parameter authTokens: The current tokens to be refreshed
   /// - Returns: New authentication tokens from the server
-  /// - Throws: An error if the refresh operation fails
+  /// - Throws:
+  ///   - ``AuthTokens/Error/refreshRejected`` to signal a definitive server-side
+  ///     rejection (see above).
+  ///   - Any other error to signal a transient failure (network, timeout, decode,
+  ///     etc.). These are rethrown to the caller of `refreshExpiredTokens()` and
+  ///     leave the stored tokens untouched.
   public var refresh: @Sendable (_ authTokens: AuthTokens) async throws -> AuthTokens
 }
 
@@ -125,16 +168,39 @@ extension JWTAuthClient {
   /// attempts to refresh it using the refresh token. The new tokens are
   /// automatically persisted to the keychain and updated in the shared session.
   ///
-  /// If the refresh operation fails (e.g., refresh token is also expired),
-  /// all authentication tokens are destroyed, effectively logging out the user.
+  /// ## Error handling
   ///
-  /// - Throws: `AuthTokens.Error.missingToken` if no tokens are available
+  /// How this method reacts to a failure of the `refresh` closure depends on
+  /// *what* error is thrown:
+  ///
+  /// - If `refresh` throws ``AuthTokens/Error/refreshRejected`` — meaning the
+  ///   server definitively rejected the refresh token (e.g. 401 from
+  ///   `/auth/refresh`, revoked refresh token) — the stored credentials are
+  ///   destroyed, the session becomes `.missing`, and this method returns
+  ///   without throwing. Callers that fall through to `session?.tokens` (like
+  ///   `sendAuthenticated`) will then see no tokens and throw
+  ///   ``AuthTokens/Error/missingToken`` themselves.
+  /// - If `refresh` throws *any other* error — meaning the failure is
+  ///   transient (no network, timeout, DNS failure, decode error, server
+  ///   unreachable, etc.) — the stored credentials are **left intact** so a
+  ///   later retry can succeed. The error is rethrown so callers can decide
+  ///   whether to surface a retry option instead of silently logging the user
+  ///   out.
+  ///
+  /// In other words: only an explicit rejection from the server destroys the
+  /// session. Anything else is treated as a transient hiccup and the user
+  /// keeps their session.
+  ///
+  /// - Throws:
+  ///   - ``AuthTokens/Error/missingToken`` if no tokens are available.
+  ///   - Any error thrown by `refresh` (other than ``AuthTokens/Error/refreshRejected``)
+  ///     — see "Error handling" above.
   ///
   /// ## Usage
   ///
   /// ```swift
   /// @Dependency(\.jwtAuthClient) var authClient
-  /// 
+  ///
   /// // Manually refresh tokens
   /// try await authClient.refreshExpiredTokens()
   /// ```
@@ -159,8 +225,25 @@ extension JWTAuthClient {
       do {
         let newTokens = try await refresh(tokens)
         try await authTokensClient.set(newTokens)
-      } catch {
+      } catch AuthTokens.Error.refreshRejected {
+        // The server explicitly rejected the refresh token (e.g. 401 from
+        // /auth/refresh, revoked/expired refresh token). Credentials are no
+        // longer valid — destroy them so the user is forced to re-authenticate.
+        //
+        // This branch intentionally does NOT rethrow so that callers like
+        // `sendAuthenticated` keep falling through to their existing
+        // `session?.tokens` check (which then throws `.missingToken`).
         try await authTokensClient.destroy()
+      } catch {
+        // Transient failure: the request didn't even reach a definitive
+        // "your refresh token is invalid" answer. Common causes are
+        // `URLError.cannotConnectToHost`, `.notConnectedToInternet`,
+        // `.timedOut`, DNS failures, decode errors, 5xx responses, etc.
+        //
+        // Leave the existing tokens in place so a later retry can succeed,
+        // and rethrow so the caller can decide whether to surface a retry
+        // option rather than silently logging the user out.
+        throw error
       }
     }
   }

--- a/Sources/JWTAuth/JWTAuthClient.swift
+++ b/Sources/JWTAuth/JWTAuthClient.swift
@@ -185,7 +185,12 @@ extension JWTAuthClient {
   ///   unreachable, etc.) — the stored credentials are **left intact** so a
   ///   later retry can succeed. The error is rethrown so callers can decide
   ///   whether to surface a retry option instead of silently logging the user
-  ///   out.
+  ///   out. If `authTokensClient.set(newTokens)` was what actually threw (for
+  ///   example a keychain save failure), the in-memory session is rolled
+  ///   back to the old `.expired(tokens)` — the live `AuthTokensClient`
+  ///   writes new tokens to memory before attempting the keychain writes,
+  ///   so without this rollback memory would be left on the new tokens while
+  ///   the keychain is empty.
   ///
   /// In other words: only an explicit rejection from the server destroys the
   /// session. Anything else is treated as a transient hiccup and the user
@@ -240,9 +245,17 @@ extension JWTAuthClient {
         // `URLError.cannotConnectToHost`, `.notConnectedToInternet`,
         // `.timedOut`, DNS failures, decode errors, 5xx responses, etc.
         //
-        // Leave the existing tokens in place so a later retry can succeed,
-        // and rethrow so the caller can decide whether to surface a retry
-        // option rather than silently logging the user out.
+        // This branch also covers the `authTokensClient.set(newTokens)`
+        // step throwing — e.g. a keychain save failure. The live
+        // `AuthTokensClient` writes the new tokens to `@Shared(.authSession)`
+        // *before* attempting the keychain writes, so on `set` failure
+        // memory would otherwise be left on the new tokens even though the
+        // keychain is empty/partial. Roll the in-memory session back to the
+        // old `.expired(tokens)` so a later retry has the original refresh
+        // token to work with.
+        if session?.tokens != tokens {
+          $session.withLock { $0 = .expired(tokens) }
+        }
         throw error
       }
     }

--- a/Sources/JWTAuth/JWTAuthClient.swift
+++ b/Sources/JWTAuth/JWTAuthClient.swift
@@ -185,12 +185,17 @@ extension JWTAuthClient {
   ///   unreachable, etc.) — the stored credentials are **left intact** so a
   ///   later retry can succeed. The error is rethrown so callers can decide
   ///   whether to surface a retry option instead of silently logging the user
-  ///   out. If `authTokensClient.set(newTokens)` was what actually threw (for
-  ///   example a keychain save failure), the in-memory session is rolled
-  ///   back to the old `.expired(tokens)` — the live `AuthTokensClient`
-  ///   writes new tokens to memory before attempting the keychain writes,
-  ///   so without this rollback memory would be left on the new tokens while
-  ///   the keychain is empty.
+  ///   out. A concurrent session change (logout, new-user login) that lands
+  ///   while the refresh is in flight is therefore preserved.
+  /// - If `authTokensClient.set(newTokens)` throws (for example a keychain
+  ///   save failure), the in-memory session is rolled back to the old
+  ///   `.expired(tokens)` — the live `AuthTokensClient` writes the new tokens
+  ///   to `@Shared(.authSession)` before attempting the keychain writes, so
+  ///   without this rollback memory would be left on the new tokens while the
+  ///   keychain is partial. The check-and-rollback is performed atomically
+  ///   via `withLock` so a concurrent session change observed during the
+  ///   catch is not overwritten — we only roll back when the session still
+  ///   holds the new tokens we just persisted.
   ///
   /// In other words: only an explicit rejection from the server destroys the
   /// session. Anything else is treated as a transient hiccup and the user
@@ -200,6 +205,8 @@ extension JWTAuthClient {
   ///   - ``AuthTokens/Error/missingToken`` if no tokens are available.
   ///   - Any error thrown by `refresh` (other than ``AuthTokens/Error/refreshRejected``)
   ///     — see "Error handling" above.
+  ///   - Any error thrown by `authTokensClient.set(newTokens)`, after rolling
+  ///     back the in-memory session.
   ///
   /// ## Usage
   ///
@@ -227,34 +234,45 @@ extension JWTAuthClient {
     do {
       try tokens.validateAccessToken()
     } catch {
+      // Step 1: ask the server for fresh tokens. A transient failure
+      // here (URLError, timeout, DNS, decode, etc.) just rethrows
+      // without touching the session — no memory mutation has happened,
+      // and we must not undo a concurrent logout/new-user login that
+      // landed while the refresh was in flight.
+      let newTokens: AuthTokens
       do {
-        let newTokens = try await refresh(tokens)
-        try await authTokensClient.set(newTokens)
+        newTokens = try await refresh(tokens)
       } catch AuthTokens.Error.refreshRejected {
-        // The server explicitly rejected the refresh token (e.g. 401 from
-        // /auth/refresh, revoked/expired refresh token). Credentials are no
-        // longer valid — destroy them so the user is forced to re-authenticate.
-        //
-        // This branch intentionally does NOT rethrow so that callers like
-        // `sendAuthenticated` keep falling through to their existing
-        // `session?.tokens` check (which then throws `.missingToken`).
+        // The server explicitly rejected the refresh token (e.g. 401
+        // from /auth/refresh, revoked/expired refresh token).
+        // Credentials are no longer valid — destroy them so the user
+        // is forced to re-authenticate. This branch intentionally
+        // does NOT rethrow so that callers like `sendAuthenticated`
+        // keep falling through to their existing `session?.tokens`
+        // check (which then throws `.missingToken`).
         try await authTokensClient.destroy()
+        return
       } catch {
-        // Transient failure: the request didn't even reach a definitive
-        // "your refresh token is invalid" answer. Common causes are
-        // `URLError.cannotConnectToHost`, `.notConnectedToInternet`,
-        // `.timedOut`, DNS failures, decode errors, 5xx responses, etc.
-        //
-        // This branch also covers the `authTokensClient.set(newTokens)`
-        // step throwing — e.g. a keychain save failure. The live
-        // `AuthTokensClient` writes the new tokens to `@Shared(.authSession)`
-        // *before* attempting the keychain writes, so on `set` failure
-        // memory would otherwise be left on the new tokens even though the
-        // keychain is empty/partial. Roll the in-memory session back to the
-        // old `.expired(tokens)` so a later retry has the original refresh
-        // token to work with.
-        if session?.tokens != tokens {
-          $session.withLock { $0 = .expired(tokens) }
+        throw error
+      }
+
+      // Step 2: persist the new tokens. The live `AuthTokensClient`
+      // writes the new tokens to `@Shared(.authSession)` *before*
+      // attempting the keychain writes, so on `set` failure memory
+      // would otherwise be left on the new tokens even though the
+      // keychain is partial. Roll the in-memory session back to the
+      // old `.expired(tokens)` so a later retry has the original
+      // refresh token to work with — but only if the session still
+      // holds the new tokens we just persisted. withLock makes the
+      // check-and-set atomic so a concurrent session change observed
+      // during the catch is not overwritten.
+      do {
+        try await authTokensClient.set(newTokens)
+      } catch {
+        $session.withLock { current in
+          if current?.tokens == newTokens {
+            current = .expired(tokens)
+          }
         }
         throw error
       }

--- a/Tests/JWTAuth/Tests.swift
+++ b/Tests/JWTAuth/Tests.swift
@@ -590,22 +590,72 @@ private final class Box<T: Sendable>: @unchecked Sendable {
   }
 }
 
-@Test func authTokensClientLiveValueSavePreservesOldRefreshOnAccessSaveFailure() async throws {
-  // The live `AuthTokensClient.persist` no longer pre-deletes the
-  // existing keychain entries before saving the new ones. So if the
-  // first save (access token) fails mid-write, the old refresh token
-  // is still in the keychain — letting a later retry succeed and
-  // avoiding a silent logout on the next cold launch. The previous
-  // delete-then-save order left the keychain completely empty on the
-  // same failure, which is what made the cold-launch case a problem.
+@Test func refreshExpiredTokensDoesNotResurrectSessionOnTransientRefreshFailure() async throws {
+  // The catch-and-rollback in `refreshExpiredTokens` must only run for
+  // failures from `authTokensClient.set(newTokens)`, NOT for failures
+  // from `refresh(tokens)`. Otherwise a concurrent session change
+  // (logout, new-user login) that lands while a refresh is in flight
+  // would be silently undone when the refresh later fails with a
+  // transient `URLError`. The mock here simulates that race by
+  // mutating the session from inside the `refresh` closure before
+  // throwing.
+  let userAExpired = AuthTokens(access: expiredJWT, refresh: "user-a-refresh")
+  let client = JWTAuthClient(
+    baseURL: { "https://api.example.com" },
+    refresh: { _ in
+      // Simulate the race: while this refresh is in flight, the
+      // user logs out (or another user logs in). The session is
+      // wiped to nil. The refresh then fails transiently.
+      @Shared(.authSession) var session
+      $session.withLock { $0 = nil }
+      throw URLError(.notConnectedToInternet)
+    }
+  )
+  await withDependencies {
+    $0.keychainClient = KeychainClient(
+      save: { _, _ in },
+      load: { _ in nil },
+      delete: { _ in },
+      reset: {}
+    )
+    $0.authTokensClient = .init(save: { _ in }, destroy: {})
+    $0.jwtAuthClient = client
+  } operation: {
+    @Shared(.authSession) var session
+    $session.withLock { $0 = .expired(userAExpired) }
+
+    await #expect(throws: URLError.self) {
+      try await client.refreshExpiredTokens()
+    }
+
+    // The session must remain nil — the rollback that was previously
+    // triggered for any non-`.refreshRejected` error would have
+    // resurrected user A's old expired tokens here, undoing the
+    // logout. The split do-catch keeps the session change intact.
+    #expect(session == nil)
+  }
+}
+
+@Test func authTokensClientLiveValueSaveRestoresOldTokensOnAccessSaveFailure() async throws {
+  // When the access-token save fails mid-write, the live
+  // `AuthTokensClient.persist` captures the old access and refresh
+  // tokens up front and best-effort restores them on partial save
+  // failure. That keeps the keychain in a cold-launch-restorable
+  // state — the next `loadTokens()` returns the old pair (or nil
+  // if there were none originally) rather than nil because one of
+  // the new saves was mid-write. Without the restore, the
+  // `KeychainClient.save` delete-then-set would leave the access
+  // entry empty after the set-throw, and the user would still be
+  // silently logged out on the next launch.
   struct AccessSaveFailed: Error {}
 
   let oldTokens = AuthTokens(access: "old-access", refresh: "old-refresh")
   let newTokens = AuthTokens(access: "new-access", refresh: "new-refresh")
-  // Track what's currently in the keychain. We mimic the live
-  // `keychainClient.save` semantics (delete-then-set on the underlying
-  // store) so this test exercises the same partial-failure shape the
-  // real keychain would produce.
+  // Track what's currently in the keychain. The stub mimics the
+  // live `keychainClient.save` semantics (delete-then-set on the
+  // underlying store) and throws *only* when the new value is being
+  // saved — the subsequent restore call with the old value is
+  // allowed to succeed.
   let storedValues = Box<[KeychainClient.Keys: String]>([
     .accessToken: oldTokens.access,
     .refreshToken: oldTokens.refresh,
@@ -615,10 +665,11 @@ private final class Box<T: Sendable>: @unchecked Sendable {
     $0.authTokensClient = .liveValue
     $0.keychainClient = KeychainClient(
       save: { value, key in
-        if storedValues.value[key] != nil {
-          storedValues.value[key] = nil
-        }
-        if key == .accessToken {
+        // Mimic live delete-then-set semantics.
+        storedValues.value[key] = nil
+        // Throw only on the new-value save; the restore call with
+        // the old value goes through cleanly.
+        if value == newTokens.access && key == .accessToken {
           throw AccessSaveFailed()
         }
         storedValues.value[key] = value
@@ -629,27 +680,30 @@ private final class Box<T: Sendable>: @unchecked Sendable {
     )
   } operation: {
     @Dependency(\.authTokensClient) var authTokensClient
+    @Dependency(\.keychainClient) var keychainClient
 
     await #expect(throws: AccessSaveFailed.self) {
       try await authTokensClient.save(newTokens)
     }
 
-    // The access-token save failed mid-way, but the refresh-token save
-    // was never attempted — so the old refresh token is still in the
-    // keychain. With the old delete-then-save persist order the
-    // pre-delete would have wiped both entries first and the keychain
-    // would be empty here.
+    // Both old tokens are back in the keychain — the access save
+    // was restored after the access-save failure, and the refresh
+    // was never touched. The keychain is cold-launch-restorable.
+    #expect(storedValues.value[.accessToken] == oldTokens.access)
     #expect(storedValues.value[.refreshToken] == oldTokens.refresh)
+    let loaded = try await keychainClient.loadTokens()
+    #expect(loaded == oldTokens)
   }
 }
 
-@Test func authTokensClientLiveValueSaveKeepsNewAccessOnRefreshSaveFailure() async throws {
-  // Companion to the access-save-failure test: when the second save
-  // (refresh token) fails, the access-token save has already
-  // succeeded, so the keychain holds the new access token. That's
-  // strictly better than the previous "keychain empty" outcome, even
-  // though it's a partial state — a later retry on the refresh path
-  // will overwrite the access token again.
+@Test func authTokensClientLiveValueSaveRestoresOldTokensOnRefreshSaveFailure() async throws {
+  // Companion case: when the access-token save succeeds but the
+  // refresh-token save fails, the live `AuthTokensClient.persist`
+  // best-effort restores the old refresh (and the old access,
+  // since the new access overwrote it). The keychain is left in a
+  // cold-launch-restorable state with the original old pair — not
+  // the new access + empty refresh that the partial fix would have
+  // left.
   struct RefreshSaveFailed: Error {}
 
   let oldTokens = AuthTokens(access: "old-access", refresh: "old-refresh")
@@ -663,13 +717,14 @@ private final class Box<T: Sendable>: @unchecked Sendable {
     $0.authTokensClient = .liveValue
     $0.keychainClient = KeychainClient(
       save: { value, key in
-        if storedValues.value[key] != nil {
-          storedValues.value[key] = nil
-        }
-        storedValues.value[key] = value
-        if key == .refreshToken {
+        // Mimic live delete-then-set semantics.
+        storedValues.value[key] = nil
+        // Throw only on the new-value save; the subsequent restore
+        // call with the old value is allowed to succeed.
+        if value == newTokens.refresh && key == .refreshToken {
           throw RefreshSaveFailed()
         }
+        storedValues.value[key] = value
       },
       load: { key in storedValues.value[key] },
       delete: { key in storedValues.value[key] = nil },
@@ -677,15 +732,19 @@ private final class Box<T: Sendable>: @unchecked Sendable {
     )
   } operation: {
     @Dependency(\.authTokensClient) var authTokensClient
+    @Dependency(\.keychainClient) var keychainClient
 
     await #expect(throws: RefreshSaveFailed.self) {
       try await authTokensClient.save(newTokens)
     }
 
-    // Access-token save completed before the refresh-token save
-    // threw, so the new access token is in the keychain. This is
-    // unchanged by the persist reorder — but verifying it here keeps
-    // the new behavior on a single set of assumptions.
-    #expect(storedValues.value[.accessToken] == newTokens.access)
+    // The new access save overwrote the old access, but the restore
+    // step put it back; the new refresh save failed before writing,
+    // so the old refresh was untouched. Keychain is the original
+    // old pair — cold-launch-restorable.
+    #expect(storedValues.value[.accessToken] == oldTokens.access)
+    #expect(storedValues.value[.refreshToken] == oldTokens.refresh)
+    let loaded = try await keychainClient.loadTokens()
+    #expect(loaded == oldTokens)
   }
 }

--- a/Tests/JWTAuth/Tests.swift
+++ b/Tests/JWTAuth/Tests.swift
@@ -536,11 +536,17 @@ private final class Box<T: Sendable>: @unchecked Sendable {
   }
 }
 
-@Test func refreshExpiredTokensKeepsTokensOnKeychainSaveFailureAfterRefresh() async throws {
+@Test func refreshExpiredTokensRollsBackSessionOnKeychainSaveFailureAfterRefresh() async throws {
   // Refresh succeeded, but persisting the new tokens to the keychain failed.
   // That's not a server-side rejection — the refresh token is still valid —
   // so we must NOT destroy, must rethrow the keychain error, and must leave
   // the existing (expired) tokens intact so a later retry can succeed.
+  //
+  // Critically, the live `AuthTokensClient.persist` writes the new tokens
+  // to `@Shared(.authSession)` *before* attempting the keychain writes.
+  // Without an explicit rollback, memory would be left on the new tokens
+  // while the keychain is empty — defeating the retry behavior. This mock
+  // reproduces that order so we can verify the rollback actually runs.
   struct KeychainSaveFailed: Error {}
 
   let expiredTokens = AuthTokens(access: expiredJWT, refresh: "refresh")
@@ -558,7 +564,14 @@ private final class Box<T: Sendable>: @unchecked Sendable {
       reset: {}
     )
     $0.authTokensClient = .init(
-      save: { _ in throw KeychainSaveFailed() },
+      save: { newTokens in
+        // Simulate live persist order: mutate memory first, then throw on
+        // the keychain write. Without rollback, `session` would be left
+        // on `newTokens` even though the keychain is empty.
+        @Shared(.authSession) var session
+        $session.withLock { $0 = newTokens.toSession() }
+        throw KeychainSaveFailed()
+      },
       destroy: { destroyCalled.value = true }
     )
     $0.jwtAuthClient = client
@@ -571,6 +584,8 @@ private final class Box<T: Sendable>: @unchecked Sendable {
     }
 
     #expect(destroyCalled.value == false)
+    // The in-memory session must be rolled back to the old expired tokens
+    // so a later retry can use the still-valid refresh token.
     #expect(session == .expired(expiredTokens))
   }
 }

--- a/Tests/JWTAuth/Tests.swift
+++ b/Tests/JWTAuth/Tests.swift
@@ -155,19 +155,23 @@ private final class Box<T: Sendable>: @unchecked Sendable {
   #expect(AuthTokens.Error.missingToken.errorDescription == "The token seems to be missing.")
   #expect(AuthTokens.Error.invalidToken.errorDescription == "The token is invalid.")
   #expect(AuthTokens.Error.expiredToken.errorDescription == "The token is expired.")
+  #expect(AuthTokens.Error.refreshRejected.errorDescription == "The refresh token was rejected by the server.")
 }
 
 @Test func authTokensErrorTitle() {
   #expect(AuthTokens.Error.missingToken.title == "Session Error")
   #expect(AuthTokens.Error.invalidToken.title == "Session Error")
   #expect(AuthTokens.Error.expiredToken.title == "Session Error")
+  #expect(AuthTokens.Error.refreshRejected.title == "Session Error")
 }
 
 @Test func authTokensErrorEquality() {
   #expect(AuthTokens.Error.missingToken == AuthTokens.Error.missingToken)
   #expect(AuthTokens.Error.invalidToken == AuthTokens.Error.invalidToken)
   #expect(AuthTokens.Error.expiredToken == AuthTokens.Error.expiredToken)
+  #expect(AuthTokens.Error.refreshRejected == AuthTokens.Error.refreshRejected)
   #expect(AuthTokens.Error.missingToken != AuthTokens.Error.invalidToken)
+  #expect(AuthTokens.Error.refreshRejected != AuthTokens.Error.expiredToken)
 }
 
 // MARK: - AuthSession Tests
@@ -412,12 +416,57 @@ private final class Box<T: Sendable>: @unchecked Sendable {
   }
 }
 
-@Test func refreshExpiredTokensDestroysTokensWhenRefreshFails() async throws {
+@Test func refreshExpiredTokensDestroysTokensWhenRefreshRejected() async throws {
   let expiredTokens = AuthTokens(access: expiredJWT, refresh: "refresh")
   let destroyCalled = Box(false)
+  let saveCalled = Box(false)
   let client = JWTAuthClient(
     baseURL: { "https://api.example.com" },
-    refresh: { _ in throw AuthTokens.Error.invalidToken }
+    refresh: { _ in throw AuthTokens.Error.refreshRejected }
+  )
+  try await withDependencies {
+    // Use a wrapping `AuthTokensClient` so we can observe `destroy`/`save`
+    // being called while still delegating to the live impl (which is what
+    // actually updates `@Shared(.authSession)` and the keychain).
+    $0.keychainClient = KeychainClient(
+      save: { _, _ in },
+      load: { _ in nil },
+      delete: { _ in },
+      reset: {}
+    )
+    $0.authTokensClient = .init(
+      save: { tokens in
+        saveCalled.value = true
+        try await AuthTokensClient.liveValue.save(tokens)
+      },
+      destroy: {
+        destroyCalled.value = true
+        try await AuthTokensClient.liveValue.destroy()
+      }
+    )
+    $0.jwtAuthClient = client
+  } operation: {
+    @Shared(.authSession) var session
+    $session.withLock { $0 = .expired(expiredTokens) }
+
+    // Server-side rejection: refreshExpiredTokens() should call destroy()
+    // and NOT rethrow — so `sendAuthenticated` can keep falling through to
+    // its existing `session?.tokens` check.
+    try await client.refreshExpiredTokens()
+
+    #expect(destroyCalled.value == true)
+    #expect(saveCalled.value == false)
+    #expect(session == nil)
+  }
+}
+
+@Test func refreshExpiredTokensKeepsTokensOnTransportError() async throws {
+  let expiredTokens = AuthTokens(access: expiredJWT, refresh: "refresh")
+  let destroyCalled = Box(false)
+  let saveCalled = Box(false)
+  let client = JWTAuthClient(
+    baseURL: { "https://api.example.com" },
+    refresh: { _ in throw URLError(.notConnectedToInternet) }
   )
   try await withDependencies {
     $0.keychainClient = KeychainClient(
@@ -426,12 +475,102 @@ private final class Box<T: Sendable>: @unchecked Sendable {
       delete: { _ in },
       reset: {}
     )
-    $0.authTokensClient = .init(save: { _ in }, destroy: { destroyCalled.value = true })
+    $0.authTokensClient = .init(
+      save: { _ in saveCalled.value = true },
+      destroy: { destroyCalled.value = true }
+    )
     $0.jwtAuthClient = client
   } operation: {
     @Shared(.authSession) var session
     $session.withLock { $0 = .expired(expiredTokens) }
-    try await client.refreshExpiredTokens()
-    #expect(destroyCalled.value == true)
+
+    // Network unreachable is a transient failure: refreshExpiredTokens()
+    // must NOT destroy the tokens, must rethrow the URLError so the caller
+    // can decide to retry, and must leave the session untouched so a later
+    // retry can succeed.
+    await #expect(throws: URLError.self) {
+      try await client.refreshExpiredTokens()
+    }
+
+    #expect(destroyCalled.value == false)
+    #expect(saveCalled.value == false)
+    #expect(session == .expired(expiredTokens))
+  }
+}
+
+@Test func refreshExpiredTokensKeepsTokensOnGenericError() async throws {
+  struct NotAServerRejection: Error, Equatable {}
+
+  let expiredTokens = AuthTokens(access: expiredJWT, refresh: "refresh")
+  let destroyCalled = Box(false)
+  let saveCalled = Box(false)
+  let client = JWTAuthClient(
+    baseURL: { "https://api.example.com" },
+    refresh: { _ in throw NotAServerRejection() }
+  )
+  try await withDependencies {
+    $0.keychainClient = KeychainClient(
+      save: { _, _ in },
+      load: { _ in nil },
+      delete: { _ in },
+      reset: {}
+    )
+    $0.authTokensClient = .init(
+      save: { _ in saveCalled.value = true },
+      destroy: { destroyCalled.value = true }
+    )
+    $0.jwtAuthClient = client
+  } operation: {
+    @Shared(.authSession) var session
+    $session.withLock { $0 = .expired(expiredTokens) }
+
+    // Any non-`.refreshRejected` error is transient: same expectations as
+    // the URLError case.
+    await #expect(throws: NotAServerRejection.self) {
+      try await client.refreshExpiredTokens()
+    }
+
+    #expect(destroyCalled.value == false)
+    #expect(saveCalled.value == false)
+    #expect(session == .expired(expiredTokens))
+  }
+}
+
+@Test func refreshExpiredTokensKeepsTokensOnKeychainSaveFailureAfterRefresh() async throws {
+  // Refresh succeeded, but persisting the new tokens to the keychain failed.
+  // That's not a server-side rejection — the refresh token is still valid —
+  // so we must NOT destroy, must rethrow the keychain error, and must leave
+  // the existing (expired) tokens intact so a later retry can succeed.
+  struct KeychainSaveFailed: Error {}
+
+  let expiredTokens = AuthTokens(access: expiredJWT, refresh: "refresh")
+  let destroyCalled = Box(false)
+  let newTokens = AuthTokens(access: validJWT, refresh: "new-refresh")
+  let client = JWTAuthClient(
+    baseURL: { "https://api.example.com" },
+    refresh: { _ in newTokens }
+  )
+  await withDependencies {
+    $0.keychainClient = KeychainClient(
+      save: { _, _ in },
+      load: { _ in nil },
+      delete: { _ in },
+      reset: {}
+    )
+    $0.authTokensClient = .init(
+      save: { _ in throw KeychainSaveFailed() },
+      destroy: { destroyCalled.value = true }
+    )
+    $0.jwtAuthClient = client
+  } operation: {
+    @Shared(.authSession) var session
+    $session.withLock { $0 = .expired(expiredTokens) }
+
+    await #expect(throws: KeychainSaveFailed.self) {
+      try await client.refreshExpiredTokens()
+    }
+
+    #expect(destroyCalled.value == false)
+    #expect(session == .expired(expiredTokens))
   }
 }

--- a/Tests/JWTAuth/Tests.swift
+++ b/Tests/JWTAuth/Tests.swift
@@ -589,3 +589,103 @@ private final class Box<T: Sendable>: @unchecked Sendable {
     #expect(session == .expired(expiredTokens))
   }
 }
+
+@Test func authTokensClientLiveValueSavePreservesOldRefreshOnAccessSaveFailure() async throws {
+  // The live `AuthTokensClient.persist` no longer pre-deletes the
+  // existing keychain entries before saving the new ones. So if the
+  // first save (access token) fails mid-write, the old refresh token
+  // is still in the keychain — letting a later retry succeed and
+  // avoiding a silent logout on the next cold launch. The previous
+  // delete-then-save order left the keychain completely empty on the
+  // same failure, which is what made the cold-launch case a problem.
+  struct AccessSaveFailed: Error {}
+
+  let oldTokens = AuthTokens(access: "old-access", refresh: "old-refresh")
+  let newTokens = AuthTokens(access: "new-access", refresh: "new-refresh")
+  // Track what's currently in the keychain. We mimic the live
+  // `keychainClient.save` semantics (delete-then-set on the underlying
+  // store) so this test exercises the same partial-failure shape the
+  // real keychain would produce.
+  let storedValues = Box<[KeychainClient.Keys: String]>([
+    .accessToken: oldTokens.access,
+    .refreshToken: oldTokens.refresh,
+  ])
+
+  try await withDependencies {
+    $0.authTokensClient = .liveValue
+    $0.keychainClient = KeychainClient(
+      save: { value, key in
+        if storedValues.value[key] != nil {
+          storedValues.value[key] = nil
+        }
+        if key == .accessToken {
+          throw AccessSaveFailed()
+        }
+        storedValues.value[key] = value
+      },
+      load: { key in storedValues.value[key] },
+      delete: { key in storedValues.value[key] = nil },
+      reset: { storedValues.value.removeAll() }
+    )
+  } operation: {
+    @Dependency(\.authTokensClient) var authTokensClient
+
+    await #expect(throws: AccessSaveFailed.self) {
+      try await authTokensClient.save(newTokens)
+    }
+
+    // The access-token save failed mid-way, but the refresh-token save
+    // was never attempted — so the old refresh token is still in the
+    // keychain. With the old delete-then-save persist order the
+    // pre-delete would have wiped both entries first and the keychain
+    // would be empty here.
+    #expect(storedValues.value[.refreshToken] == oldTokens.refresh)
+  }
+}
+
+@Test func authTokensClientLiveValueSaveKeepsNewAccessOnRefreshSaveFailure() async throws {
+  // Companion to the access-save-failure test: when the second save
+  // (refresh token) fails, the access-token save has already
+  // succeeded, so the keychain holds the new access token. That's
+  // strictly better than the previous "keychain empty" outcome, even
+  // though it's a partial state — a later retry on the refresh path
+  // will overwrite the access token again.
+  struct RefreshSaveFailed: Error {}
+
+  let oldTokens = AuthTokens(access: "old-access", refresh: "old-refresh")
+  let newTokens = AuthTokens(access: "new-access", refresh: "new-refresh")
+  let storedValues = Box<[KeychainClient.Keys: String]>([
+    .accessToken: oldTokens.access,
+    .refreshToken: oldTokens.refresh,
+  ])
+
+  try await withDependencies {
+    $0.authTokensClient = .liveValue
+    $0.keychainClient = KeychainClient(
+      save: { value, key in
+        if storedValues.value[key] != nil {
+          storedValues.value[key] = nil
+        }
+        storedValues.value[key] = value
+        if key == .refreshToken {
+          throw RefreshSaveFailed()
+        }
+      },
+      load: { key in storedValues.value[key] },
+      delete: { key in storedValues.value[key] = nil },
+      reset: { storedValues.value.removeAll() }
+    )
+  } operation: {
+    @Dependency(\.authTokensClient) var authTokensClient
+
+    await #expect(throws: RefreshSaveFailed.self) {
+      try await authTokensClient.save(newTokens)
+    }
+
+    // Access-token save completed before the refresh-token save
+    // threw, so the new access token is in the keychain. This is
+    // unchanged by the persist reorder — but verifying it here keeps
+    // the new behavior on a single set of assumptions.
+    #expect(storedValues.value[.accessToken] == newTokens.access)
+  }
+}


### PR DESCRIPTION
## Summary

`JWTAuthClient.refreshExpiredTokens()` used to treat *any* failure of the injected `refresh` closure as proof that the refresh token was invalid, and destroyed all stored credentials. That meant a transient network failure on a cold app launch (server unreachable, timeout, DNS error, decode error, etc) silently and permanently logged the user out — even though their refresh token was still perfectly valid.

This PR fixes that by introducing a typed signal — `AuthTokens.Error.refreshRejected` — that consumer `refresh` closures throw to explicitly mean *"the server definitively rejected this refresh token (e.g. 401 from `/auth/refresh`)"*. `refreshExpiredTokens()` now:

- Calls `authTokensClient.destroy()` **only** when it catches `AuthTokens.Error.refreshRejected` (the existing rejection behavior, preserved).
- Splits the rest of the workflow into two atomic steps so a transient failure of `refresh(tokens)` can never resurrect a session that was concurrently changed (logout, new-user login), and a failure of `authTokensClient.set(newTokens)` rolls the in-memory session back via a `withLock`-guarded check so the same concurrent-change race is preserved during the catch.

It also reorders `AuthTokensClient.liveValue.persist` to save-before-delete and adds a load-capture-restore step on partial save failure. Previously a keychain save failure mid-persist left the keychain empty (both entries pre-deleted before the first save), and even with the persist reorder the `KeychainClient.save` delete-then-set could leave one of the two entries empty after a set-throw. The restore step captures the old values up front and best-effort writes them back on failure so the next cold launch can still `loadTokens()` the original pair.

## Consumer contract

```swift
refresh: { tokens in
  do {
    let response: TokenResponse = try await httpClient.send(...) {
      Path("api", "v1", "auth", "refresh")
      post(RefreshTokenRequest(refreshToken: tokens.refresh), encoder: .api)
    }.value
    return AuthTokens(access: response.accessToken, refresh: response.refreshToken)
  } catch let error as APIError where error.statusCode == 401 {
    throw AuthTokens.Error.refreshRejected   // <-- new: explicit signal
  }
  // URLError, decode errors, 5xx, etc. propagate and are treated as transient.
}
```

## Behavior matrix

| `refresh` throws                       | Before                                  | After                                                |
| -------------------------------------- | --------------------------------------- | ---------------------------------------------------- |
| `AuthTokens.Error.refreshRejected`     | destroy + swallow                       | destroy + swallow *(unchanged)*                      |
| `URLError.cannotConnectToHost` etc.    | **destroy** *(wrong — user logged out)* | rethrow, session unchanged                           |
| Arbitrary non-`AuthTokens.Error`       | **destroy** *(wrong)*                   | rethrow, session unchanged                           |
| Keychain save failure after success    | **destroy** *(wrong)*                   | rethrow, session rolled back to `.expired(tokens)`   |
| Concurrent logout during transient refresh | n/a                                | not undone (no resurrection)                         |
| Keychain save failure mid-persist (cold-launch) | **keychain empty** *(wrong — silent logout)* | keychain restored to old pair, memory rolled back to `.expired(tokens)` |

`sendAuthenticated`'s existing fall-through to `session?.tokens == nil → throw .missingToken` is preserved for the rejection case.

## Tests

Updated `Tests/JWTAuth/Tests.swift`:

- `refreshExpiredTokensDestroysTokensWhenRefreshRejected` *(renamed + extended)* — `.refreshRejected` → `destroy()` called, session → `nil`, no rethrow.
- `refreshExpiredTokensKeepsTokensOnTransportError` *(new)* — `URLError(.notConnectedToInternet)` → no destroy, no save, session stays `.expired(tokens)`, error rethrown.
- `refreshExpiredTokensKeepsTokensOnGenericError` *(new)* — same for an arbitrary non-`AuthTokens.Error`.
- `refreshExpiredTokensRollsBackSessionOnKeychainSaveFailureAfterRefresh` *(renamed + extended)* — refresh succeeds, keychain `save` throws → no destroy, session preserved, error rethrown.
- `refreshExpiredTokensDoesNotResurrectSessionOnTransientRefreshFailure` *(new)* — `refresh` closure mutates session to `nil` (simulating a concurrent logout) before throwing `URLError`; session must remain `nil` afterwards (no resurrection).
- `authTokensClientLiveValueSaveRestoresOldTokensOnAccessSaveFailure` *(renamed + extended)* — uses `AuthTokensClient.liveValue` with a stubbed `KeychainClient`; on access-token save failure, both old tokens are back in the keychain and `loadTokens()` returns the old pair.
- `authTokensClientLiveValueSaveRestoresOldTokensOnRefreshSaveFailure` *(renamed + extended)* — companion case; on refresh-token save failure, the keychain is also restored to the old pair.
- `authTokensErrorDescriptions` / `authTokensErrorEquality` / `authTokensErrorTitle` updated for the new case.

All 41 tests pass.

## Docs

- `ErrorHandling.md`, `AuthenticationFlow.md`, `TokenManagement.md` — replaced the misleading "if refresh fails, destroy everything" pattern with the new destroy-vs-rethrow contract, added `.refreshRejected` to error handling examples, and added a canonical `refresh` closure example.
- `Testing.md` — updated the `failureMock` (throws `.refreshRejected`, definitive rejection) vs `networkErrorMock` (throws `URLError`, transient) mock factories, plus a `testTransientRefreshFailure` example.

## Scope

Touched in this PR (revisited across Codex review rounds):

- `AuthTokensClient.liveValue.persist` — reordered from delete-then-save to save-before-delete, and a load-capture-restore step added on partial save failure. The `save` / `destroy` / `set` call signatures and consumer-visible behavior are unchanged; only the internal ordering and the partial-failure recovery are different.
- `JWTAuthClient.refreshExpiredTokens` — the catch-and-rollback was split into two atomic `do-catch` blocks (one around `refresh`, one around `set`) so transient refresh failures no longer trigger the in-memory rollback, and the set-failure rollback uses `withLock` to make the check-and-set atomic against a concurrent session change.

## Out of scope (untouched)

- `loadSession()`, `KeychainClient` (its `liveValue` was used unchanged), `AuthSession`'s three-case model.